### PR TITLE
Added podspec

### DIFF
--- a/DynamicFonts.podspec
+++ b/DynamicFonts.podspec
@@ -1,0 +1,19 @@
+require 'json'
+package = JSON.parse(File.read(File.join(__dir__, './', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                   = "DynamicFonts"
+
+  s.version                = package['version']
+  s.homepage               = package['url']
+  s.summary                = package['description']
+  s.license                = package['license']
+  s.author                 = package['author']
+  s.source                 = { :git => package['repository']['url'] }
+
+  s.ios.deployment_target  = '9.0'
+  s.tvos.deployment_target = '9.2'
+  s.source_files           = 'DynamicFonts.{h,m}'
+  s.frameworks             = 'Foundation', 'UIKit', 'CoreText'
+  s.dependency 'React'
+end

--- a/README.md
+++ b/README.md
@@ -15,11 +15,23 @@ A React Native module that allows you to load fonts dynamically at runtime via b
 
 ### Automatic Installation
 
-`react-native link`
+If you've created your project either with `react-native init` or `create-react-native-app` you can link DynamicFonts automatically:
 
-### Manual Installation
+```bash
+react native link
+```
+
+### Alternative Installation
 
 #### iOS
+
+##### Cocoapods
+
+```podspec
+pod 'DynamicFonts', :path => 'node_modules/react-native-dynamic-fonts'
+```
+
+##### Manually
 
 1. In the XCode's "Project navigator", right click on your project's Libraries folder ➜ `Add Files to <...>`
 2. Go to `node_modules` ➜ `react-native-dynamic-fonts` ➜ `ios` ➜ select `RCTDynamicFonts.xcodeproj`


### PR DESCRIPTION
If you integrate ReactNative in an [existing](https://facebook.github.io/react-native/docs/integration-with-existing-apps) codebase Cocoapods installation is preferred*

I've added a podspec so Cocoapods users don't have to do the manual installation. 

*(I'm not completely sure, but `react-native link` is not even working in my RN project.)